### PR TITLE
Fix on heightForHeaderInSection

### DIFF
--- a/StaticDataTableViewController.m
+++ b/StaticDataTableViewController.m
@@ -438,7 +438,7 @@
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
     
-    CGFloat height = [super tableView:tableView heightForFooterInSection:section];
+    CGFloat height = [super tableView:tableView heightForHeaderInSection:section];
     
     if (self.originalTable == nil) {
         return height;


### PR DESCRIPTION
The height for headerInSection method was calling super
heightForFooterInSection instead of super heightForHeaderInSection
