### PR TITLE
Add support to set height for cell

### DIFF
--- a/StaticDataTableViewController.h
+++ b/StaticDataTableViewController.h
@@ -30,6 +30,10 @@
 
 - (void)cells:(NSArray *)cells setHidden:(BOOL)hidden;
 
+- (void)cell:(UITableViewCell *)cell setHeight:(CGFloat)height;
+
+- (void)cells:(NSArray *)cells setHeight:(CGFloat)height;
+
 // never call [self.tableView reloadData] directly
 // doing so will lead to data inconsistenci
 // always use this method for reload

--- a/StaticDataTableViewController.m
+++ b/StaticDataTableViewController.m
@@ -33,11 +33,23 @@
 
 @property (nonatomic, strong) NSIndexPath * originalIndexPath;
 
+@property (nonatomic, assign) CGFloat height;
+
 - (void)update;
 
 @end
 
 @implementation OriginalRow
+
+- (id)init {
+    self = [super init];
+    
+    if (self) {
+        self.height = CGFLOAT_MAX;
+    }
+    
+    return self;
+}
 
 - (BOOL)hidden {
     return (self.hiddenPlanned || self.hiddenPlanned);
@@ -372,6 +384,19 @@
     }
 }
 
+- (void)cell:(UITableViewCell *)cell setHeight:(CGFloat)height {
+    
+    OriginalRow * row = [self.originalTable originalRowWithTableViewCell:cell];
+    [row setHeight:height];
+    
+}
+
+- (void)cells:(NSArray *)cells setHeight:(CGFloat)height {
+    for (UITableViewCell * cell in cells) {
+        [self cell:cell setHeight:height];
+    }
+}
+
 - (BOOL)cellIsHidden:(UITableViewCell *)cell {
     return [[self.originalTable originalRowWithTableViewCell:cell] hidden];
 }
@@ -440,6 +465,11 @@
 {
     if (self.originalTable != nil) {
         OriginalRow * or = [self.originalTable vissibleOriginalRowWithIndexPath:indexPath];
+        
+        if (or.height != CGFLOAT_MAX) {
+            return or.height;
+        }
+        
         indexPath = or.originalIndexPath;
     }
     return [super tableView:tableView heightForRowAtIndexPath:indexPath];


### PR DESCRIPTION
I needed a way to change the height of cells dynamically.
I tried to use `tableView:heightForRowAtIndexPath:` delegate method with no success.
Therefore I added `cell:setHeight` and `cells:setHeight` functions to solve the problem.

Example:
Consider `self.descriptionCell` a property that references a cell in the static UITableView.
```
[self cell:self.descriptionCell setHeight:100];
[self reloadDataAnimated:YES];
```